### PR TITLE
Count confidence relative to latest block height

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/TransactionConfidence.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionConfidence.java
@@ -368,8 +368,9 @@ public class TransactionConfidence {
      *
      * @return the new depth
      */
-    public synchronized int incrementDepthInBlocks() {
-        return ++this.depth;
+    public synchronized int incrementDepthInBlocks(int height) {
+        this.depth = height - getAppearedAtChainHeight() + 1;
+        return this.depth;
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/wallet/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Wallet.java
@@ -2138,7 +2138,7 @@ public class Wallet extends BaseTaggableObject
                         // included once again. We could have a separate was-in-chain-and-now-isn't confidence type
                         // but this way is backwards compatible with existing software, and the new state probably
                         // wouldn't mean anything different to just remembering peers anyway.
-                        if (confidence.incrementDepthInBlocks() > context.getEventHorizon())
+                        if (confidence.incrementDepthInBlocks(block.getHeight()) > context.getEventHorizon())
                             confidence.clearBroadcastBy();
                         confidenceChanged.put(tx, TransactionConfidence.Listener.ChangeReason.DEPTH);
                     }


### PR DESCRIPTION
Problem: One transaction can belong to multiple wallets so it would
count the depth twice for each block

Solution: Count depth as current block height - seen block height + 1

