### PR TITLE
Add check to not duplicate peers

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.bitcoinj</groupId>
         <artifactId>bitcoinj-parent</artifactId>
-        <version>0.14.4.8</version>
+        <version>0.14.4.9</version>
     </parent>
 
     <artifactId>bitcoinj-core</artifactId>

--- a/core/src/main/java/org/bitcoinj/core/PeerGroup.java
+++ b/core/src/main/java/org/bitcoinj/core/PeerGroup.java
@@ -619,7 +619,9 @@ public class PeerGroup implements TransactionBroadcaster {
                 if (retryTime > now) {
                     long delay = retryTime - now;
                     log.info("Waiting {} msec before next connect attempt {}", delay, addrToTry == null ? "" : "to " + addrToTry);
-                    inactives.add(addrToTry);
+
+                    if (!isAlreadyAdded(addrToTry))
+                        inactives.add(addrToTry);
                     executor.schedule(this, delay, TimeUnit.MILLISECONDS);
                     return;
                 }
@@ -637,6 +639,17 @@ public class PeerGroup implements TransactionBroadcaster {
             }
         }
     };
+
+    private boolean isAlreadyAdded(PeerAddress peerAddress) {
+        boolean isAlreadyAdded = false;
+        for (PeerAddress a : inactives) {
+            if (a.getHostname().equals(peerAddress.getHostname())) {
+                isAlreadyAdded = true;
+                break;
+            }
+        }
+        return isAlreadyAdded;
+    }
 
     private void triggerConnections() {
         // Run on a background thread due to the need to potentially retry and back off in the background.
@@ -1038,7 +1051,10 @@ public class PeerGroup implements TransactionBroadcaster {
                 return false;
             }
             backoffMap.put(peerAddress, new ExponentialBackoff(peerBackoffParams));
-            inactives.offer(peerAddress);
+
+            if (!isAlreadyAdded(peerAddress))
+                inactives.offer(peerAddress);
+
             return true;
         } finally {
             lock.unlock();

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.bitcoinj</groupId>
         <artifactId>bitcoinj-parent</artifactId>
-        <version>0.14.4.8</version>
+        <version>0.14.4.9</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.bitcoinj</groupId>
   <artifactId>bitcoinj-parent</artifactId>
-    <version>0.14.4.8</version>
+    <version>0.14.4.9</version>
   <packaging>pom</packaging>
 
   <modules>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.bitcoinj</groupId>
     <artifactId>bitcoinj-parent</artifactId>
-      <version>0.14.4.8</version>
+      <version>0.14.4.9</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/wallettemplate/pom.xml
+++ b/wallettemplate/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.bitcoinj</groupId>
         <artifactId>bitcoinj-parent</artifactId>
-        <version>0.14.4.8</version>
+        <version>0.14.4.9</version>
     </parent>
 
     <artifactId>wallettemplate</artifactId>


### PR DESCRIPTION
The inactives collection contained duplicated peerAddresses after
connection loss and reconnect.
We add a check to see if the to-get-added peerAddress is not already
in the collection and only add it if it is absent.
This problem was not discovered when using the public network as the
chance that same peerAddress get reported is pretty low. But with our
provided nodes we got frequently duplicates.
    
Fixes https://github.com/bisq-network/bisq/issues/1703