### PR TITLE
Clone transaction before adding to wallet

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/PeerGroup.java
+++ b/core/src/main/java/org/bitcoinj/core/PeerGroup.java
@@ -2260,10 +2260,7 @@ public class PeerGroup implements TransactionBroadcaster {
                     // We may end up with two threads trying to do this in parallel - the wallet will
                     // ignore whichever one loses the race.
                     try {
-                        // Clone transaction before adding to pending to avoid multiple wallets pointing to the same
-                        // transaction. This can happen when two wallets depend on the same transaction.
-                        wallet.receivePending(
-                                new Transaction(transaction.getParams(), transaction.bitcoinSerialize()), null);
+                        wallet.receivePending(transaction, null);
                     } catch (VerificationException e) {
                         throw new RuntimeException(e);   // Cannot fail to verify a tx we created ourselves.
                     }

--- a/core/src/main/java/org/bitcoinj/core/PeerGroup.java
+++ b/core/src/main/java/org/bitcoinj/core/PeerGroup.java
@@ -2260,7 +2260,10 @@ public class PeerGroup implements TransactionBroadcaster {
                     // We may end up with two threads trying to do this in parallel - the wallet will
                     // ignore whichever one loses the race.
                     try {
-                        wallet.receivePending(transaction, null);
+                        // Clone transaction before adding to pending to avoid multiple wallets pointing to the same
+                        // transaction. This can happen when two wallets depend on the same transaction.
+                        wallet.receivePending(
+                                new Transaction(transaction.getParams(), transaction.bitcoinSerialize()), null);
                     } catch (VerificationException e) {
                         throw new RuntimeException(e);   // Cannot fail to verify a tx we created ourselves.
                     }

--- a/core/src/main/java/org/bitcoinj/core/TransactionConfidence.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionConfidence.java
@@ -368,9 +368,8 @@ public class TransactionConfidence {
      *
      * @return the new depth
      */
-    public synchronized int incrementDepthInBlocks(int height) {
-        this.depth = height - getAppearedAtChainHeight() + 1;
-        return this.depth;
+    public synchronized int incrementDepthInBlocks() {
+        return ++this.depth;
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/core/TransactionConfidence.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionConfidence.java
@@ -112,12 +112,12 @@ public class TransactionConfidence {
          * If a transaction hasn't been broadcast yet, or there's no record of it, its confidence is UNKNOWN.
          */
         UNKNOWN(0);
-
+        
         private int value;
         ConfidenceType(int value) {
             this.value = value;
         }
-
+        
         public int getValue() {
             return value;
         }
@@ -262,7 +262,7 @@ public class TransactionConfidence {
     }
 
     /**
-     * Called by other objects in the system, like a {@link Wallet}, when new information about the confidence of a
+     * Called by other objects in the system, like a {@link Wallet}, when new information about the confidence of a 
      * transaction becomes available.
      */
     public synchronized void setConfidenceType(ConfidenceType confidenceType) {
@@ -369,9 +369,7 @@ public class TransactionConfidence {
      * @return the new depth
      */
     public synchronized int incrementDepthInBlocks(int height) {
-        if (getAppearedAtChainHeight() != -1)
-            this.depth = height - getAppearedAtChainHeight() + 1;
-
+        this.depth = height - getAppearedAtChainHeight() + 1;
         return this.depth;
     }
 
@@ -381,7 +379,7 @@ public class TransactionConfidence {
      * considers a transaction impractical to reverse after 6 blocks, but as of EOY 2011 network
      * security is high enough that often only one block is considered enough even for high value transactions. For low
      * value transactions like songs, or other cheap items, no blocks at all may be necessary.</p>
-     *
+     *     
      * <p>If the transaction appears in the top block, the depth is one. If it's anything else (pending, dead, unknown)
      * the depth is zero.</p>
      */

--- a/core/src/main/java/org/bitcoinj/wallet/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Wallet.java
@@ -1683,6 +1683,11 @@ public class Wallet extends BaseTaggableObject
         // returned true, so we already know by this point that it sends coins to or from our wallet, or is a double
         // spend against one of our other pending transactions.
         lock.lock();
+
+        // Clone transaction to avoid multiple wallets pointing to the same transaction. This can happen when
+        // two wallets depend on the same transaction.
+        tx = tx.getParams().getDefaultSerializer().makeTransaction(tx.bitcoinSerialize());
+
         try {
             tx.verify();
             // Ignore it if we already know about this transaction. Receiving a pending transaction never moves it

--- a/core/src/main/java/org/bitcoinj/wallet/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Wallet.java
@@ -2143,7 +2143,7 @@ public class Wallet extends BaseTaggableObject
                         // included once again. We could have a separate was-in-chain-and-now-isn't confidence type
                         // but this way is backwards compatible with existing software, and the new state probably
                         // wouldn't mean anything different to just remembering peers anyway.
-                        if (confidence.incrementDepthInBlocks(block.getHeight()) > context.getEventHorizon())
+                        if (confidence.incrementDepthInBlocks() > context.getEventHorizon())
                             confidence.clearBroadcastBy();
                         confidenceChanged.put(tx, TransactionConfidence.Listener.ChangeReason.DEPTH);
                     }

--- a/core/src/main/java/org/bitcoinj/wallet/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Wallet.java
@@ -376,7 +376,7 @@ public class Wallet extends BaseTaggableObject
     public DeterministicKeyChain getActiveKeychain() {
         return keyChainGroup.getActiveKeyChain();
     }
-
+    
     /**
      * <p>Adds given transaction signer to the list of signers. It will be added to the end of the signers list, so if
      * this wallet already has some signers added, given signer will be executed after all of them.</p>
@@ -823,7 +823,7 @@ public class Wallet extends BaseTaggableObject
     /**
      * Returns whether this wallet consists entirely of watching keys (unencrypted keys with no private part). Mixed
      * wallets are forbidden.
-     *
+     * 
      * @throws IllegalStateException
      *             if there are no keys, or if there is a mix between watching and non-watching keys.
      */
@@ -2123,8 +2123,7 @@ public class Wallet extends BaseTaggableObject
         try {
             // Store the new block hash.
             setLastBlockSeenHash(newBlockHash);
-            final int blockHeight = block.getHeight();
-            setLastBlockSeenHeight(blockHeight);
+            setLastBlockSeenHeight(block.getHeight());
             setLastBlockSeenTimeSecs(block.getHeader().getTimeSeconds());
             // Notify all the BUILDING transactions of the new block.
             // This is so that they can update their depth.
@@ -2144,7 +2143,7 @@ public class Wallet extends BaseTaggableObject
                         // included once again. We could have a separate was-in-chain-and-now-isn't confidence type
                         // but this way is backwards compatible with existing software, and the new state probably
                         // wouldn't mean anything different to just remembering peers anyway.
-                        if (confidence.incrementDepthInBlocks(blockHeight) > context.getEventHorizon())
+                        if (confidence.incrementDepthInBlocks(block.getHeight()) > context.getEventHorizon())
                             confidence.clearBroadcastBy();
                         confidenceChanged.put(tx, TransactionConfidence.Listener.ChangeReason.DEPTH);
                     }
@@ -4670,10 +4669,10 @@ public class Wallet extends BaseTaggableObject
      * <p>Gets a bloom filter that contains all of the public keys from this wallet, and which will provide the given
      * false-positive rate if it has size elements. Keep in mind that you will get 2 elements in the bloom filter for
      * each key in the wallet, for the public key and the hash of the public key (address form).</p>
-     *
+     * 
      * <p>This is used to generate a BloomFilter which can be {@link BloomFilter#merge(BloomFilter)}d with another.
      * It could also be used if you have a specific target for the filter's size.</p>
-     *
+     * 
      * <p>See the docs for {@link BloomFilter(int, double)} for a brief explanation of anonymity when using bloom
      * filters.</p>
      */
@@ -4867,7 +4866,7 @@ public class Wallet extends BaseTaggableObject
             } else {
                 fees = fees.add(req.feePerKb);  // First time around the loop.
             }
-
+            
             if (needAtLeastReferenceFee && fees.compareTo(Transaction.REFERENCE_DEFAULT_MIN_TX_FEE) < 0)
                 fees = Transaction.REFERENCE_DEFAULT_MIN_TX_FEE;
 


### PR DESCRIPTION
Since PeerGroup can have multiple wallets that all might depend on the
same transaction it was adding the same transaction to multiple wallets.
By cloning the transaction each wallet is guaranteed to have its own,
non shared transactions