### PR TITLE
Transaction.unCache() set confidence to null

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Transaction.java
+++ b/core/src/main/java/org/bitcoinj/core/Transaction.java
@@ -527,6 +527,7 @@ public class Transaction extends ChildMessage {
     protected void unCache() {
         super.unCache();
         hash = null;
+        confidence = null;
     }
 
     protected static int calcLength(byte[] buf, int offset) {


### PR DESCRIPTION
Fixes https://github.com/bisq-network/bisq/issues/2639