### PR TITLE
Permit listening to version messages

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.google.protobuf'
 apply plugin: 'maven'
 apply plugin: 'eclipse'
 
-version = '0.15.8.bisq.13'
+version = '0.15.8.bisq.14'
 archivesBaseName = 'bitcoinj-core'
 eclipse.project.name = 'bitcoinj-core'
 

--- a/core/src/main/java/org/bitcoinj/core/Peer.java
+++ b/core/src/main/java/org/bitcoinj/core/Peer.java
@@ -470,8 +470,8 @@ public class Peer extends PeerSocketHandler {
             currentFilteredBlock = null;
         }
 
-        // No further communication is possible until version handshake is complete.
-        if (!(m instanceof VersionMessage || m instanceof VersionAck
+        // Most further communication isn't possible until version handshake is complete.
+        if (!(m instanceof VersionMessage || m instanceof VersionAck || m instanceof AlertMessage
                 || (versionHandshakeFuture.isDone() && !versionHandshakeFuture.isCancelled())))
             throw new ProtocolException(
                     "Received " + m.getClass().getSimpleName() + " before version handshake is complete.");

--- a/core/src/main/java/org/bitcoinj/core/VersionMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/VersionMessage.java
@@ -32,19 +32,19 @@ import java.util.Locale;
 
 /**
  * <p>A VersionMessage holds information exchanged during connection setup with another peer. Most of the fields are not
- * particularly interesting. The subVer field, since BIP 14, acts as a User-Agent string would. You can and should 
+ * particularly interesting. The subVer field, since BIP 14, acts as a User-Agent string would. You can and should
  * append to or change the subVer for your own software so other implementations can identify it, and you can look at
  * the subVer field received from other nodes to see what they are running.</p>
  *
  * <p>After creating yourself a VersionMessage, you can pass it to {@link PeerGroup#setVersionMessage(VersionMessage)}
  * to ensure it will be used for each new connection.</p>
- * 
+ *
  * <p>Instances of this class are not safe for use by multiple threads.</p>
  */
 public class VersionMessage extends Message {
 
     /** The version of this library release, as a string. */
-    public static final String BITCOINJ_VERSION = "0.15.8.bisq.13";
+    public static final String BITCOINJ_VERSION = "0.15.8.bisq.14";
     /** The value that is prepended to the subVer field of this application. */
     public static final String LIBRARY_SUBVER = "/bitcoinj:" + BITCOINJ_VERSION + "/";
 
@@ -103,7 +103,7 @@ public class VersionMessage extends Message {
     // It doesn't really make sense to ever lazily parse a version message or to retain the backing bytes.
     // If you're receiving this on the wire you need to check the protocol version and it will never need to be sent
     // back down the wire.
-    
+
     public VersionMessage(NetworkParameters params, int newBestHeight) {
         super(params);
         clientVersion = params.getProtocolVersionNum(NetworkParameters.ProtocolVersion.CURRENT);

--- a/core/src/main/java/org/bitcoinj/core/listeners/VersionMessageReceivedEventListener.java
+++ b/core/src/main/java/org/bitcoinj/core/listeners/VersionMessageReceivedEventListener.java
@@ -23,10 +23,12 @@ import org.bitcoinj.core.VersionMessage;
 public interface VersionMessageReceivedEventListener {
 
     /**
-     * Called when a peer's VersionMessage is received during handshake.
+     * Called when a peer's VersionMessage is received during handshake. Peer's VersionMessage
+     * may be accessed through the Peer object; however, it is null until it is received. Here
+     * the VersionMessage is passed explicitly to be unambigious about its availability.
      *
-     * @param peer
-     * @param peerCount the total number of connected peers
+     * @param peer the peer receiving the VersionMessage
+     * @param versionMessage the received VersionMessage
      */
     void onVersionMessageReceived(Peer peer, VersionMessage versionMessage);
 }

--- a/core/src/main/java/org/bitcoinj/core/listeners/VersionMessageReceivedEventListener.java
+++ b/core/src/main/java/org/bitcoinj/core/listeners/VersionMessageReceivedEventListener.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bitcoinj.core.listeners;
+
+import org.bitcoinj.core.Peer;
+import org.bitcoinj.core.VersionMessage;
+
+/**
+ * <p>Implementors can listen to events indicating a peer's VersionMessage receival during handshake.</p>
+ */
+public interface VersionMessageReceivedEventListener {
+
+    /**
+     * Called when a peer's VersionMessage is received during handshake.
+     *
+     * @param peer
+     * @param peerCount the total number of connected peers
+     */
+    void onVersionMessageReceived(Peer peer, VersionMessage versionMessage);
+}


### PR DESCRIPTION
This is the porting of PR #35 to BitcoinJ 15.8. I'll copy-paste the general description:

> Since Bisq requires nodes with specific configuration (as reflected in
their version messages), we also want to handle misconfigured nodes,
especially in cases where the user expects that node to be used. To get
access to all received version messages, a new listener is introduced.
Existing listeners are not sufficient, because in some cases BitcoinJ
will kill the Peer (connection to a node) before any of them are
triggered. This listener will always be triggered when a VersionMessage
is received.

Practically no code changes were required to apply this to 15.8. I copy-pasted the changes one by one anyway to make sure, hence different set of commits.