### PR TITLE
Clone transaction before committing to wallet

### DIFF
--- a/core/src/main/java/org/bitcoinj/wallet/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Wallet.java
@@ -1891,7 +1891,13 @@ public class Wallet extends BaseTaggableObject
                 return;
             if (isTransactionRisky(tx, dependencies) && !acceptRiskyTransactions) {
                 // isTransactionRisky already logged the reason.
-                riskDropped.put(tx.getTxId(), tx);
+
+                // Clone transaction to avoid multiple wallets pointing to the same transaction. This can happen when
+                // two wallets depend on the same transaction.
+                Transaction cloneTx = tx.getParams().getDefaultSerializer().makeTransaction(tx.bitcoinSerialize());
+                cloneTx.setPurpose(tx.getPurpose());
+
+                riskDropped.put(cloneTx.getTxId(), cloneTx);
                 log.warn("There are now {} risk dropped transactions being kept in memory", riskDropped.size());
                 return;
             }
@@ -1903,10 +1909,16 @@ public class Wallet extends BaseTaggableObject
             if (tx.getConfidence().getSource().equals(TransactionConfidence.Source.UNKNOWN)) {
                 log.warn("Wallet received transaction with an unknown source. Consider tagging it!");
             }
+
+            // Clone transaction to avoid multiple wallets pointing to the same transaction. This can happen when
+            // two wallets depend on the same transaction.
+            Transaction cloneTx = tx.getParams().getDefaultSerializer().makeTransaction(tx.bitcoinSerialize());
+            cloneTx.setPurpose(tx.getPurpose());
+
             // If this tx spends any of our unspent outputs, mark them as spent now, then add to the pending pool. This
             // ensures that if some other client that has our keys broadcasts a spend we stay in sync. Also updates the
             // timestamp on the transaction and registers/runs event listeners.
-            commitTx(tx);
+            commitTx(cloneTx);
         } finally {
             lock.unlock();
         }


### PR DESCRIPTION
This is basically the same PR as https://github.com/bisq-network/bitcoinj/pull/21 but it's now a real issue. This PR also clones `purpose` which wasn't done in the earlier PR.

Atomic transactions that have inputs and outputs relating to two wallets are received from the network and added through `receivePending()`. To avoid adding the same instance of a transaction to two wallets a clone is made and added instead. These transactions come from the network so they don't yet have any wallet data associated with them.
