### PR TITLE
Reduce log level of two messages which frequently fill user's log.

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/PeerGroup.java
+++ b/core/src/main/java/org/bitcoinj/core/PeerGroup.java
@@ -540,7 +540,7 @@ public class PeerGroup implements TransactionBroadcaster {
                 if (inactives.isEmpty()) {
                     if (countConnectedAndPendingPeers() < getMaxConnections()) {
                         long interval = Math.max(groupBackoff.getRetryTime() - now, MIN_PEER_DISCOVERY_INTERVAL);
-                        log.info("Peer discovery didn't provide us any more peers, will try again in "
+                        log.debug("Peer discovery didn't provide us any more peers, will try again in "
                             + interval + "ms.");
                         executor.schedule(this, interval, TimeUnit.MILLISECONDS);
                     } else {
@@ -1047,7 +1047,7 @@ public class PeerGroup implements TransactionBroadcaster {
             }
         }
         watch.stop();
-        log.info("Peer discovery took {} and returned {} items", watch, addressList.size());
+        log.debug("Peer discovery took {} and returned {} items", watch, addressList.size());
         return addressList.size();
     }
 


### PR DESCRIPTION
Bisq can get into a state where it checks for network peers constantly, filling the logs with the connection attempts. e.g. Peer discovery didn't provide us any more peers, will try again in 10000ms According to the log message, there should be a 10000ms delay between connection attempts, but examples clearly contradict this. The problem with these messages spamming all 20 logfiles is that it prevents other, valid trade issues from being investigated. A high percentage of supplied user logs contain examples of this. I'm hoping this can be fixed in Bisq's fork of BitcoinJ.

Fixes https://github.com/bisq-network/bisq/issues/5996