### PR TITLE
StoredBlock: use Utils.bigIntegerToBytes to convert chainWork (Backport)

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/StoredBlock.java
+++ b/core/src/main/java/org/bitcoinj/core/StoredBlock.java
@@ -117,8 +117,7 @@ public class StoredBlock {
 
     /** Serializes the stored block to a custom packed format. Used by {@link CheckpointManager}. */
     public void serializeCompact(ByteBuffer buffer) {
-        byte[] chainWorkBytes = getChainWork().toByteArray();
-        checkState(chainWorkBytes.length <= CHAIN_WORK_BYTES, "Ran out of space to store chain work!");
+        byte[] chainWorkBytes = Utils.bigIntegerToBytes(getChainWork(), CHAIN_WORK_BYTES);
         if (chainWorkBytes.length < CHAIN_WORK_BYTES) {
             // Pad to the right size.
             buffer.put(EMPTY_BYTES, 0, CHAIN_WORK_BYTES - chainWorkBytes.length);


### PR DESCRIPTION
Critical upstream fix!

Fixes [#7168](https://github.com/bisq-network/bisq/issues/7168)

https://github.com/bitcoinj/bitcoinj/issues/3410

https://github.com/bitcoinj/bitcoinj/pull/3412